### PR TITLE
Fix initial connection failure

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -24,7 +24,7 @@ class Backend(BackendBase):
 
     def connect(self) -> bool:
         host = self.frontend.get_settings().get("ip", "localhost")
-        port = self.frontend.get_settings().get("port", 4455),
+        port = self.frontend.get_settings().get("port", 4455)
         password = self.frontend.get_settings().get("password") or ""
 
         return self.connect_to(host, port, password)


### PR DESCRIPTION
When launching this backend, this plugin would consistently log the following two errors:

    ValueError: Port could not be cast to integer value as '(4455,)'
    2026-03-25 05:07:56.121 | ERROR    | __main__:connect_to:67 - Failed to connect to OBS: Port could not be cast to integer value as '(4455,)'

The plugin would function correctly after this.

This PR removes a stray comma which was causing this error to appear.