### PR TITLE
Remove logging suppression for obsws-python

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -3,20 +3,6 @@ import obsws_python as obs
 from loguru import logger as log
 from obsws_python.error import OBSSDKRequestError
 import uuid
-import logging
-import threading
-
-class _ThreadBoundFilter(logging.Filter):
-    """Temporarily suppress sub‑CRITICAL log records from the creating thread only."""
-
-    def __init__(self):
-        super().__init__()
-        self._thread_id = threading.get_ident()
-
-    def filter(self, record):
-        if threading.get_ident() == self._thread_id:
-            return record.levelno >= logging.CRITICAL
-        return True
 
 
 class Backend(BackendBase):
@@ -67,10 +53,6 @@ class Backend(BackendBase):
             log.error("Invalid IP address for OBS connection")
             return False
 
-        obs_logger = logging.getLogger("obsws_python")
-        obs_filter = _ThreadBoundFilter()
-        obs_logger.addFilter(obs_filter)
-
         try:
             log.debug("Trying to connect to OBS")
             self.obs_client = obs.ReqClient(
@@ -93,8 +75,6 @@ class Backend(BackendBase):
             log.error(f"Failed to connect to OBS: {e}")
             self.connected = False
             return False
-        finally:
-            obs_logger.removeFilter(obs_filter)
 
     def get_connected(self) -> bool:
         return self.connected


### PR DESCRIPTION
With https://github.com/aatikturk/obsws-python/pull/76, `obsws-python` does not print an ERROR log on every failed connection attempt. Because of this, we do not need to suppress non-CRITICAL logs from the library anymore.  This patch removes that supression logic.