### PR TITLE
Always initialize `source_model` in `_populate_source_model`

### DIFF
--- a/actions/TimerSourceActionCore.py
+++ b/actions/TimerSourceActionCore.py
@@ -88,12 +88,12 @@ class TimerSourceActionCore(OBSLiveSplitOneCore):
             self.set_settings(settings)
 
     def _populate_source_model(self):
+        self.source_model = Gio.ListStore()
+
         if not self.plugin_base.get_connected():
             self.reconnect_obs()
         if not self.plugin_base.get_connected():
             return
-
-        self.source_model = Gio.ListStore()
         sources = sorted(
             self.plugin_base.backend.get_all_livesplit_one_sources(),
             key=lambda source: source["name"]


### PR DESCRIPTION
When the OBS connection is unavailable, `_populate_source_model` returns early without setting `self.source_model`.  This causes an `AttributeError` when `load_config_defaults` subsequently calls `self.source_model.get_n_items()`, breaking the configuration UI.

This patch moves the `Gio.ListStore()` initialization to the top of `_populate_source_model`, before the connection check and early return.  After this change, `load_config_defaults` sees an empty model (zero items) and safely falls through to the `else` branch without error.